### PR TITLE
Fix FileBrowser-PNP persistence and permissions (v1.1.0)

### DIFF
--- a/file_browser_pnp/file_browser_pnp.xml
+++ b/file_browser_pnp/file_browser_pnp.xml
@@ -14,12 +14,13 @@
   <Overview>File Browser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files. It allows the creation of multiple users and each user can have its own directory.&#xD;&#xD;
 This software was created by the File Browser Team. This container is pulled from the official File Browser repo and has been configured for simple one-click install with improved instructions and configs.&#xD;&#xD;
 Instructions:&#xD;
-1. Set desired webUI port (Default 8080)&#xD;
-2. Set the directory you wish to access from the webUI&#xD;
+1. Set desired webUI port (Default 8080).&#xD;
+2. Set the directory you wish to access from the WebUI.&#xD;
 3. Deploy!&#xD;
-4. Login with the default credentials, User: admin, Pass: admin&#xD;
-5. Change the default password asap!&#xD;
-6. Enjoy!&#xD;&#xD;
+4. On first launch, check the container logs for your randomly generated admin password.&#xD;
+5. Log in at the WebUI using the default username "admin" and the password from the logs.&#xD;
+6. Change the default password ASAP!&#xD;
+7. Enjoy!&#xD;&#xD;
 Part of the Plug-and-Play-Docker Repo set of apps by logandwaters.&#xD;&#xD;
 Helpful links Below.&#xD;&#xD;
 Official GitHub Repo: https://github.com/filebrowser/filebrowser&#xD;
@@ -27,21 +28,30 @@ Official Docs: https://filebrowser.org/&#xD;
 Report Software Issues: https://github.com/filebrowser/filebrowser/issues&#xD;
 Report Container Template Issue: https://github.com/logandwaters/Plug-and-Play-Docker/issues</Overview>
 
+  <Requires>Before first deployment, run the following in the Unraid terminal to create the required paths and permissions:&#xD;&#xD;
+mkdir -p /mnt/user/appdata/filebrowser&#xD;
+touch /mnt/user/appdata/filebrowser/filebrowser.db&#xD;
+chown -R 1000:1000 /mnt/user/appdata/filebrowser&#xD;
+chmod -R 775 /mnt/user/appdata/filebrowser</Requires>
+
   <Category>Cloud: Productivity: Tools: Other: Status:Stable</Category>
-  <WebUI>http://[IP]:[PORT:8080]</WebUI>
+  <WebUI>http://[IP]:[PORT:80]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/logandwaters/Plug-and-Play-Docker/refs/heads/main/file_browser_pnp/file_browser_pnp.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/logandwaters/Plug-and-Play-Docker/refs/heads/main/file_browser_pnp/logo.png</Icon>
   <ExtraParams/>
   <PostArgs/>
   <CPUset/>
-  <DateInstalled>1729963700</DateInstalled>
 
   <!-- Port Configuration -->
-  <Config Name="WebUI Port" Target="80" Default="8080" Description="Binds the Host Port (Default of 8080) to the internal container port of 80 for UI access" Type="Port" Display="always" Required="true"/>
+  <Config Name="WebUI Port" Target="80" Default="8080" Description="Host port (Default 8080) mapped to container port 80 for UI access." Type="Port" Display="always" Required="true"/>
 
   <!-- Volume Configuration -->
-  <Config Name="Path of Directory to Access" Target="/srv" Default="" Description="Specify the path you would like to access within the UI" Type="Path" Display="always" Required="true"/>
-  <Config Name="Path to Database" Target="/db" Default="/mnt/user/appdata/filebrowser/db" Description="Path to the built-in database (do not change)" Type="Path" Display="always" Required="false"/>
+  <Config Name="Path of Directory to Access" Target="/srv" Default="/mnt/user" Description="Directory to access within the UI." Type="Path" Display="always" Required="true"/>
+  <Config Name="Path to Config" Target="/config" Default="/mnt/user/appdata/filebrowser" Description="Stores configuration and settings.json." Type="Path" Display="always" Required="true"/>
+  <Config Name="Path to Database File" Target="/database.db" Default="/mnt/user/appdata/filebrowser/filebrowser.db" Description="Persistent database file for users and settings." Type="Path" Display="always" Required="true"/>
+
+  <!-- Environment Variables -->
+  <Config Name="File Browser Database Path" Target="FB_DATABASE" Default="/database.db" Description="Forces File Browser to use the mapped database file for persistence." Type="Variable" Display="always" Required="true"/>
 
   <MySource>https://github.com/filebrowser/filebrowser</MySource>
 </Container>


### PR DESCRIPTION
### Summary
This PR updates the **FileBrowser-PNP** template to version **v1.1.0**, resolving persistence and configuration issues introduced in the initial release.

---

### Changes Made
- Fixed incorrect volume and variable mappings that caused configuration resets  
- Updated default paths for config and database files  
- Cleaned up XML formatting and comments for Unraid compatibility  
- Improved user instructions and overview for clarity  
- Verified Unraid CA compatibility and persistence behavior  

---

### Notes
- This update aligns the template with **File Browser’s** current directory structure and environment variable requirements.  
- File Browser is now in maintenance mode; further version updates may be limited.  
- Tested and confirmed functional with Unraid 7.0.0.  

---

### Release
**Version:** `v1.1.0`  
**Date:** October 21, 2025  
**Status:** Ready for merge into `main`